### PR TITLE
docs: fix errors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## Features
 
 - Mobile, tablet & desktop friendly
-- Uses WP rest API to avoid unecessary full-page reloads
+- Uses WP REST API to avoid unnecessary full-page reloads
 - Styled w/ SASS using the SCSS (Sassy CSS) syntax
 - Gulp for automated prefixing, minification w/ sourcemaps & BrowserSync
 - Easy to build upon!


### PR DESCRIPTION
- “rest” -> “REST” (REST is an acronym and should be capitalized)
- “unecessary” -> “unnecessary” (incorrect spelling)